### PR TITLE
fix(locale): get_format doesn't override number formatting if use_l10n is None

### DIFF
--- a/app/apps/common/functions/format.py
+++ b/app/apps/common/functions/format.py
@@ -5,7 +5,12 @@ from django.utils.formats import get_format as original_get_format
 def get_format(format_type=None, lang=None, use_l10n=None):
     user = get_current_user()
 
-    if user and user.is_authenticated and hasattr(user, "settings") and use_l10n:
+    if (
+        user
+        and user.is_authenticated
+        and hasattr(user, "settings")
+        and use_l10n is not False
+    ):
         user_settings = user.settings
         if format_type == "THOUSAND_SEPARATOR":
             number_format = getattr(user_settings, "number_format", None)

--- a/app/apps/common/widgets/decimal.py
+++ b/app/apps/common/widgets/decimal.py
@@ -35,8 +35,7 @@ class ArbitraryDecimalDisplayNumberInput(forms.TextInput):
         self.attrs.update(
             {
                 "x-data": "",
-                "x-mask:dynamic": f"$money($input, '{get_format('DECIMAL_SEPARATOR')}', "
-                f"'{get_format('THOUSAND_SEPARATOR')}', '30')",
+                "x-mask:dynamic": f"$money($input, '{get_format('DECIMAL_SEPARATOR')}', '{get_format('THOUSAND_SEPARATOR')}', '30')",
                 "x-on:keyup": "$el.dispatchEvent(new Event('input'))",
             }
         )


### PR DESCRIPTION
Fixes #322