### PR TITLE
fix(app): pwa title colour

### DIFF
--- a/app/templates/includes/head/favicons.html
+++ b/app/templates/includes/head/favicons.html
@@ -12,6 +12,4 @@
 <link rel="icon" type="image/png" sizes="32x32" href="{% static 'img/favicon/favicon-32x32.png' %}">
 <link rel="icon" type="image/png" sizes="96x96" href="{% static 'img/favicon/favicon-96x96.png' %}">
 <link rel="icon" type="image/png" sizes="16x16" href="{% static 'img/favicon/favicon-16x16.png' %}">
-<meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="{% static 'img/favicon/ms-icon-144x144.png' %}">
-<meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
Current situation: The current PWA is showing the title bar as white

<details><summary>Screenshot of how it is now</summary>
<img width="1122" height="946" alt="image" src="https://github.com/user-attachments/assets/6416ff8e-6c80-47c0-be64-48ea13d60bd4" />
</details>

---

Expectation: It is expected to be the accent colour of the application.

Django PWA already correctly sets the title based on settings.py, but the colour is being overridden by these values in head.

<details><summary>Screenshot of expected colour</summary>
<img width="1122" height="946" alt="image" src="https://github.com/user-attachments/assets/5a597594-c690-448a-be94-2d2aff8d98e3" />
</details>

---

Django PWA settings already set here:
https://github.com/eitchtee/WYGIWYH/blob/main/app/WYGIWYH/settings.py#L496

Django PWA example in their README and templates:
https://github.com/silviolleite/django-pwa/blob/master/README.md?plain=1#L51
https://github.com/silviolleite/django-pwa/blob/master/src/pwa/templates/pwa.html#L10

---

Just a tiny contribution - feel free to reject if it does not align with the design :)