### PR TITLE
fix(api): inefficient transaction update operation

### DIFF
--- a/app/apps/api/views/transactions.py
+++ b/app/apps/api/views/transactions.py
@@ -32,7 +32,7 @@ class TransactionViewSet(viewsets.ModelViewSet):
         transaction_created.send(sender=instance)
 
     def perform_update(self, serializer):
-        old_data = deepcopy(Transaction.objects.get(pk=serializer.data["pk"]))
+        old_data = deepcopy(self.get_object())
         instance = serializer.save()
         transaction_updated.send(sender=instance, old_data=old_data)
 


### PR DESCRIPTION
Updates TransactionViewSet `perform_update` method to use DRF's `get_object()` to avoid unnecessary serialization.

Fixes #427