### PR TITLE
Add token authentication to the API

### DIFF
--- a/app/WYGIWYH/settings.py
+++ b/app/WYGIWYH/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     "apps.api.apps.ApiConfig",
     "cachalot",
     "rest_framework",
+    "rest_framework.authtoken",
     "drf_spectacular",
     "django_cotton",
     "apps.rules.apps.RulesConfig",
@@ -432,6 +433,11 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "apps.api.permissions.NotInDemoMode",
         "rest_framework.permissions.DjangoModelPermissions",
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,


### PR DESCRIPTION
# Closes: #471 

This PR adds token authentication to the API.
Tokens can be managed via the Django Admin page