### PR TITLE
Dca strategy api fix

### DIFF
--- a/app/apps/api/views/dca.py
+++ b/app/apps/api/views/dca.py
@@ -6,7 +6,7 @@ from apps.api.serializers import DCAStrategySerializer, DCAEntrySerializer
 
 
 class DCAStrategyViewSet(viewsets.ModelViewSet):
-    queryset = DCAStrategy.objects.all()
+    queryset = DCAStrategy.all_objects.all()
     serializer_class = DCAStrategySerializer
 
     @action(detail=True, methods=["get"])


### PR DESCRIPTION
Fixes: #487

Use the .all_objects queryset manager, which shows all objects, not only the shared ones