### PR TITLE
fix: recurring tags and entities dropped when generated for another user

### DIFF
--- a/app/apps/transactions/models.py
+++ b/app/apps/transactions/models.py
@@ -937,8 +937,10 @@ class RecurringTransaction(models.Model):
             notes=self.notes if self.add_notes_to_transaction else "",
             owner=self.account.owner,
         )
-        created_transaction.tags.set(self.tags.all())
-        created_transaction.entities.set(self.entities.all())
+        # Unfiltered managers: generation also runs without a current user, or with a
+        # different one, and the scoped default manager would hide private rows.
+        created_transaction.tags.set(self.tags(manager="all_objects").all())
+        created_transaction.entities.set(self.entities(manager="all_objects").all())
 
     def get_recurrence_delta(self):
         if self.recurrence_type == self.RecurrenceType.DAY:
@@ -1030,9 +1032,11 @@ class RecurringTransaction(models.Model):
                 self.notes if self.add_notes_to_transaction else ""
             )
 
-            # Update many-to-many relationships
-            existing_transaction.tags.set(self.tags.all())
-            existing_transaction.entities.set(self.entities.all())
+            # Update many-to-many relationships (see create_transaction)
+            existing_transaction.tags.set(self.tags(manager="all_objects").all())
+            existing_transaction.entities.set(
+                self.entities(manager="all_objects").all()
+            )
 
             # Save updated transaction
             existing_transaction.save()

--- a/app/apps/transactions/tests/test_models.py
+++ b/app/apps/transactions/tests/test_models.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from apps.transactions.models import (
     TransactionCategory,
     TransactionTag,
+    TransactionEntity,
     Transaction,
     InstallmentPlan,
     RecurringTransaction,
@@ -240,3 +241,27 @@ class RecurringTransactionTests(TestCase):
         self.assertFalse(recurring.is_paused)
         self.assertEqual(recurring.recurrence_interval, 1)
         self.assertEqual(recurring.account.currency.code, "USD")
+
+    def test_generate_upcoming_transactions_keeps_tags_and_entities(self):
+        """Generation must copy tags/entities even with no current user"""
+        tag = TransactionTag.objects.create(name="Essential")
+        entity = TransactionEntity.objects.create(name="Landlord")
+        recurring = RecurringTransaction.objects.create(
+            account=self.account,
+            type=Transaction.Type.EXPENSE,
+            amount=Decimal("100.00"),
+            description="Monthly Payment",
+            start_date=timezone.now().date(),
+            recurrence_type=RecurringTransaction.RecurrenceType.MONTH,
+            recurrence_interval=1,
+        )
+        recurring.tags.set([tag])
+        recurring.entities.set([entity])
+
+        RecurringTransaction.generate_upcoming_transactions()
+
+        generated = Transaction.all_objects.filter(recurring_transaction=recurring)
+        self.assertTrue(generated.exists())
+        for transaction in generated:
+            self.assertIn(tag, transaction.tags(manager="all_objects").all())
+            self.assertIn(entity, transaction.entities(manager="all_objects").all())


### PR DESCRIPTION
## Problem

On current `main`, tags and entities are dropped from transactions generated by `RecurringTransaction.generate_upcoming_transactions`. Creating a transaction from the UI keeps them.

Cause: **`self.tags` and `self.entities` resolve through the owner-scoped `SharedObjectManager`**, which returns `filter(visibility="public")` when there is no current user. `visibility` defaults to private, so private tags and entities are dropped. `category` is a plain FK and survives, which is why the symptom looks partial.

The scheduler (`apps/transactions/tasks.py:21`) hits this with no user. There is also a wrong-user variant: `generate_upcoming_transactions` is a `@classmethod` iterating `cls.all_objects` over every user, and it is called from a request too (`forms.py:1156`), so user A saving a recurring transaction strips user B's private tags from B's future transactions.

`edcad379` removed the `if self.tags.exists():` wrappers here; `exists()` goes through the same scoped manager, so it was already false for the same reason. What remains is the queryset itself.


## Change

Read the M2M through the unfiltered manager, via Django's related-manager override so the relation direction and the default reverse query name stay untouched.

`InstallmentPlan` has the same pattern, but all its callers are request-bound with no all-users loop, so nothing there is affected. Left alone; happy to convert for consistency if you prefer.


## Verification

`test_generate_upcoming_transactions_keeps_tags_and_entities`, added to the existing `RecurringTransactionTests`: fails on `main`, passes with the change.

Running on my own instance since mid-July, where it fixed exactly this — nightly-generated transactions arriving with no tags. That build used the equivalent `TransactionTag.all_objects.filter(recurringtransaction=self)` form.
